### PR TITLE
feat: Add search and CSV export to item registration screen

### DIFF
--- a/database_manager.py
+++ b/database_manager.py
@@ -27,7 +27,7 @@ def dict_factory(cursor, row):
     return {col[0]: row[idx] for idx, col in enumerate(cursor.description)}
 
 # --- Funções CRUD: Itens ---
-def get_all_items():
+def get_all_items(search_term: str = None):
     with db_connect() as conn:
         query = """
             SELECT
@@ -37,9 +37,15 @@ def get_all_items():
                 COALESCE(f.nome, 'N/A') as fornecedor_nome
             FROM itens i
             LEFT JOIN fornecedores f ON i.fornecedor_id = f.id
-            ORDER BY i.nome
         """
-        return conn.cursor().execute(query).fetchall()
+        params = []
+        if search_term:
+            query += " WHERE i.nome LIKE ? OR i.codigo LIKE ?"
+            params.append(f"%{search_term}%")
+            params.append(f"%{search_term}%")
+
+        query += " ORDER BY i.nome"
+        return conn.cursor().execute(query, params).fetchall()
 
 def get_item_by_id(item_id):
     with db_connect() as conn:

--- a/tela_cadastro_item.py
+++ b/tela_cadastro_item.py
@@ -10,6 +10,7 @@ from PyQt6.QtGui import QIntValidator, QDoubleValidator, QIcon
 import database_manager
 import logging
 import os
+import csv
 from io import BytesIO
 
 # Imports necessários para a geração de PDF
@@ -97,6 +98,16 @@ class CadastroItemWindow(QDialog):
         buttons_layout.addWidget(self.generate_qr_button)
         main_layout.addLayout(buttons_layout)
 
+        # Layout para busca e exportação
+        table_actions_layout = QHBoxLayout()
+        self.search_input = QLineEdit(placeholderText="Buscar por código ou nome...")
+        self.search_input.textChanged.connect(self.filter_table)
+        table_actions_layout.addWidget(self.search_input)
+
+        self.export_button = QPushButton("Exportar CSV", clicked=self.export_to_csv, objectName="secondaryButton")
+        table_actions_layout.addWidget(self.export_button)
+        main_layout.addLayout(table_actions_layout)
+
         self.table_itens = QTableWidget()
         self.table_itens.setColumnCount(8)
         self.table_itens.setHorizontalHeaderLabels(["ID", "Código", "Nome", "Descrição", "UM", "Est. Mín.", "Preço Custo", "Fornecedor"])
@@ -118,9 +129,9 @@ class CadastroItemWindow(QDialog):
             for f in fornecedores:
                 self.fornecedor_combo.addItem(f['nome'], f['id'])
 
-    def load_items_to_table(self):
+    def load_items_to_table(self, search_term: str = None):
         self.table_itens.setRowCount(0)
-        itens = database_manager.get_all_items()
+        itens = database_manager.get_all_items(search_term)
         self.table_itens.setRowCount(len(itens))
         for row, item in enumerate(itens):
             self.table_itens.setItem(row, 0, QTableWidgetItem(str(item['id'])))
@@ -132,6 +143,10 @@ class CadastroItemWindow(QDialog):
             preco_str = f"R$ {item.get('preco_unitario', 0):.2f}".replace('.', ',')
             self.table_itens.setItem(row, 6, QTableWidgetItem(preco_str))
             self.table_itens.setItem(row, 7, QTableWidgetItem(item['fornecedor_nome']))
+
+    def filter_table(self):
+        search_term = self.search_input.text().strip()
+        self.load_items_to_table(search_term)
 
     def on_selection_changed(self):
         if not self.table_itens.selectedItems():
@@ -228,6 +243,25 @@ class CadastroItemWindow(QDialog):
                 self.clear_form(ask_confirmation=False)
             else:
                 QMessageBox.critical(self, "Erro", f"Erro ao excluir item: {message}")
+
+    def export_to_csv(self):
+        """Exporta os itens visíveis na tabela para um arquivo CSV."""
+        path, _ = QFileDialog.getSaveFileName(self, "Salvar como CSV", "itens.csv", "CSV Files (*.csv)")
+        if not path:
+            return
+
+        try:
+            with open(path, 'w', newline='', encoding='utf-8') as file:
+                writer = csv.writer(file)
+                headers = [self.table_itens.horizontalHeaderItem(i).text() for i in range(self.table_itens.columnCount())]
+                writer.writerow(headers)
+
+                for row in range(self.table_itens.rowCount()):
+                    row_data = [self.table_itens.item(row, col).text() for col in range(self.table_itens.columnCount())]
+                    writer.writerow(row_data)
+            QMessageBox.information(self, "Sucesso", f"Dados exportados com sucesso para:\n{path}")
+        except Exception as e:
+            QMessageBox.critical(self, "Erro ao Exportar", f"Ocorreu um erro: {e}")
 
     def generate_qr_label(self):
         """Gera uma etiqueta QR Code para o item selecionado em formato PDF."""

--- a/test_database_manager.py
+++ b/test_database_manager.py
@@ -59,6 +59,29 @@ class TestDatabaseManager(unittest.TestCase):
         self.assertFalse(success)
         self.assertIn("já existe", message)
 
+    def test_get_all_items_with_search(self):
+        """Testa a busca de itens com termo de pesquisa."""
+        all_items = database_manager.get_all_items()
+        self.assertEqual(len(all_items), 2)
+
+        # Busca por nome
+        items_1 = database_manager.get_all_items(search_term="Item 1")
+        self.assertEqual(len(items_1), 1)
+        self.assertEqual(items_1[0]['nome'], "Item 1")
+
+        # Busca por código
+        items_2 = database_manager.get_all_items(search_term="ITM002")
+        self.assertEqual(len(items_2), 1)
+        self.assertEqual(items_2[0]['codigo'], "ITM002")
+
+        # Busca por termo parcial
+        items_partial = database_manager.get_all_items(search_term="ITM")
+        self.assertEqual(len(items_partial), 2)
+
+        # Busca por termo inexistente
+        items_none = database_manager.get_all_items(search_term="Inexistente")
+        self.assertEqual(len(items_none), 0)
+
     def test_update_item(self):
         """Testa a atualização de um item."""
         item1 = database_manager.get_item_by_code("ITM001")


### PR DESCRIPTION
This commit introduces two main enhancements to the item registration screen (`tela_cadastro_item.py`):

1.  **Item Search/Filter:** A search bar has been added to the UI, allowing users to filter the item list in real-time by typing a search term. The filtering is performed on both the item's name and code.

2.  **CSV Export:** An "Exportar CSV" button has been added, which allows users to save the currently displayed list of items to a CSV file.

To support these features, the `database_manager.py` file was refactored to allow the `get_all_items` function to accept a search term and filter the database query accordingly.

Unit tests have been added to `test_database_manager.py` to validate the new search functionality.